### PR TITLE
Improve logging and error reporting (#18)

### DIFF
--- a/docs/ru/usage.rst
+++ b/docs/ru/usage.rst
@@ -27,7 +27,7 @@
 описание всех параметров запустите команду с опцией ``--help`` или ``-h``::
 
     % ged2doc --help
-    usage: ged2doc [-h] [-v] [--version] [-i PATH] [-p PATTERN]
+    usage: ged2doc [-h] [-v] [--log PATH] [--version] [-i PATH] [-p PATTERN]
                    [--encoding ENCODING] [--encoding-errors MODE] [-t {html,odt}]
                    [-l LANG_CODE] [-d FMT] [-s ORDER] [--no-missing-date]
                    [--no-image] [--no-toc] [--no-stat] [-w NUMBER]
@@ -53,6 +53,7 @@
       -h, --help            show this help message and exit
       -v, --verbose         Print some info to standard output, -vv prints debug
                             info.
+      --log PATH            Produces log file with debugging information.
       --version             Print version information and exit
 
     ... description of all other options ...
@@ -355,6 +356,18 @@ utf-8, но заменяет неправильно закодированные
 --first-page NUMBER      Номер первой страницы; по умолчанию ``1``. Можно
         изменить на другое значение, если вы планируете добавлять
         дополнительные страницы в начале при печати окончательного документа.
+
+Диагностика
+^^^^^^^^^^^
+
+В случае сбоя приложения или получения неправильного или неожиданного вывода
+желательно сгенерировать журнальный файл с диагностикой и переслать его автору
+(чтобы сообщить об ошибках см. *Contributing*). Для создания журнального
+файла используйте опцию ``--log``, например::
+
+    $ ged2doc --log=log.txt input.ged page.html
+
+что создаст файл ``log.txt`` в текущем рабочем каталоге.
 
 Примеры
 ^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,7 +27,7 @@ appearance of the produced output document. To get a brief description of
 all options run the command with ``--help`` or ``-h`` option::
 
     % ged2doc --help
-    usage: ged2doc [-h] [-v] [--version] [-i PATH] [-p PATTERN]
+    usage: ged2doc [-h] [-v] [--log PATH] [--version] [-i PATH] [-p PATTERN]
                    [--encoding ENCODING] [--encoding-errors MODE] [-t {html,odt}]
                    [-l LANG_CODE] [-d FMT] [-s ORDER] [--no-missing-date]
                    [--no-image] [--no-toc] [--no-stat] [-w NUMBER]
@@ -53,6 +53,7 @@ all options run the command with ``--help`` or ``-h`` option::
       -h, --help            show this help message and exit
       -v, --verbose         Print some info to standard output, -vv prints debug
                             info.
+      --log PATH            Produces log file with debugging information.
       --version             Print version information and exit
 
     ... description of all other options ...
@@ -345,6 +346,18 @@ Options specific to ODT output:
 --first-page NUMBER      Number of the first page; default: ``1``. Can be
         changed to something different if you plan to add extra pages
         at the beginning when printing the final document.
+
+Logging
+^^^^^^^
+
+In case application crashes or produces incorrect or unexpected output it
+would be helpful to produce log file with debug information and forward it
+to author (see *Contributing* for how to report bugs). To produce log file
+use ``--log`` option, e.g.::
+
+    $ ged2doc --log=log.txt input.ged page.html
+
+which will create ``log.txt`` file in a current working directory.
 
 Examples
 ^^^^^^^^

--- a/ged2doc/html_writer.py
+++ b/ged2doc/html_writer.py
@@ -326,7 +326,8 @@ class HtmlWriter(writer.Writer):
             imgfile = io.BytesIO()
             mimetype = utils.img_save(newimg, imgfile)
             if mimetype:
-                tag = '<img class="personImage" src="data:{mime};base64,{data}"/>'
+                tag = '<img class="personImage" '\
+                      'src="data:{mime};base64,{data}"/>'
                 data = base64.b64encode(imgfile.getvalue()).decode('ascii')
                 return tag.format(mime=mimetype, data=data)
 


### PR DESCRIPTION
Added --log option to log everything to a log file. Do not dump
traceback to console, only print shorter and cleaner error message.